### PR TITLE
feat,popout: this commit wires in litee.nvim popout feature

### DIFF
--- a/doc/litee-calltree.txt
+++ b/doc/litee-calltree.txt
@@ -92,6 +92,8 @@ To toggle the panel open and close use the following command
     -- panel component. Only valid if a Calltree is open and "LTCloseCalltree" has
     -- not been called on the current tab.
     vim.cmd("command! LTOpenToCalltree      lua require('litee.calltree').open_to()")
+    -- Uses litee.nvim's Popout feature to popout the calltree to a floating window.
+    vim.cmd("command! LTPopOutCalltree      lua require('litee.calltree').popout_to()")
     -- When called on a specific tabpage any Calltree UI will be closed and cleared
     -- from the panel. Toggling the panel will not open the most recent Calltree.
     vim.cmd("command! LTCloseCalltree       lua require('litee.calltree').close_calltree()")
@@ -186,6 +188,9 @@ The config table is described below:
         map_resize_keys = true,
         -- Disables all highlighting.
         no_hls = false,
+        -- Determines if initial creation of a calltree opens in the
+        -- Panel or in a Popout window.
+        on_open = "popout"
     }
 
 Any overrides to this table can be supplied in the setup function:

--- a/lua/litee/calltree/autocmds.lua
+++ b/lua/litee/calltree/autocmds.lua
@@ -71,4 +71,5 @@ M.auto_highlight = function(set)
     end
     lib_autohi.highlight(ctx.node, set, ctx.state["calltree"].invoking_win)
 end
+
 return M

--- a/lua/litee/calltree/buffer.lua
+++ b/lua/litee/calltree/buffer.lua
@@ -63,6 +63,7 @@ function M._setup_buffer(name, buf, tab)
     vim.api.nvim_buf_set_keymap(buf, "n", "S", ":LTSwitchCalltree<CR>", opts)
     vim.api.nvim_buf_set_keymap(buf, "n", "H", ":LTHideCalltree<CR>", opts)
     vim.api.nvim_buf_set_keymap(buf, "n", "X", ":LTCloseCalltree<CR>", opts)
+    vim.api.nvim_buf_set_keymap(buf, "n", "<Esc>", ":LTClosePanelPopOut<CR>", opts)
     vim.api.nvim_buf_set_keymap(buf, "n", "?", ":lua require('litee.calltree').help(true)<CR>", opts)
 	if config.map_resize_keys then
            lib_util_buf.map_resize_keys(panel_config.orientation, buf, opts)

--- a/lua/litee/calltree/commands.lua
+++ b/lua/litee/calltree/commands.lua
@@ -2,6 +2,7 @@ local M = {}
 
 function M.setup()
     vim.cmd("command! LTOpenToCalltree      lua require('litee.calltree').open_to()")
+    vim.cmd("command! LTPopOutCalltree      lua require('litee.calltree').popout_to()")
     vim.cmd("command! LTCloseCalltree       lua require('litee.calltree').close_calltree()")
     vim.cmd("command! LTNextCalltree        lua require('litee.calltree').navigation('n')")
     vim.cmd("command! LTPrevCalltree        lua require('litee.calltree').navigation('p')")

--- a/lua/litee/calltree/config.lua
+++ b/lua/litee/calltree/config.lua
@@ -8,6 +8,7 @@ M.config = {
     map_resize_keys = true,
     no_hls = false,
     auto_highlight = true,
+    on_open = "popout"
 }
 
 return M


### PR DESCRIPTION
this commit wires in the new litee.nvim popout feature.

the calltree can now be popped out from the panel to a floating window
with the command "LTPopOutCalltree"

additionally a config option "on_open" is added which takes the
arguments "popout" or "panel". if set to "panel" the first request for a
calltree is opened in the panel, same goes for "popout".