### PR TITLE
Prevent MethodNotFound errors from being printed

### DIFF
--- a/lua/litee/calltree/handlers.lua
+++ b/lua/litee/calltree/handlers.lua
@@ -179,7 +179,10 @@ end
 function M.calltree_expand_handler(node, linenr, direction, state)
     return function(err, result, _, _)
         if err ~= nil then
-            vim.api.nvim_err_writeln(vim.inspect(err))
+            -- don't log any error if the langserver does not support the request
+            if err.code and err.code ~= -32601 then
+                vim.api.nvim_err_writeln(vim.inspect(err))
+            end
             return
         end
         if result == nil then


### PR DESCRIPTION
This plugin is awesome, and it really helped me with finding traces of calls through a complex code base. Thank you!

I noticed something though, I run multiple language servers usually, one for the language and one for separate formatters and linters, and whenever I want to expand the calltree, I get an error from those servers that do not support the incoming/outgoing calls. This PR just checks if the error on expansion is the `MethodNotSupported` and silently ignores it. Any other errors are logged.